### PR TITLE
Remove obselete future template tag

### DIFF
--- a/flat/templates/accounts/account_login.html
+++ b/flat/templates/accounts/account_login.html
@@ -1,5 +1,5 @@
 {% extends "accounts/account_form.html" %}
-{% load i18n future %}
+{% load i18n %}
 
 {% block main %}
 <section id="registration" class="container">

--- a/flat/templates/accounts/account_profile.html
+++ b/flat/templates/accounts/account_profile.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n future mezzanine_tags accounts_tags %}
+{% load i18n mezzanine_tags accounts_tags %}
 
 {% block meta_title %}{{ profile_user|username_or:"get_full_name" }}{% endblock %}
 {% block title %}{{ profile_user|username_or:"get_full_name" }}{% endblock %}

--- a/flat/templates/accounts/includes/user_panel.html
+++ b/flat/templates/accounts/includes/user_panel.html
@@ -1,4 +1,4 @@
-{% load i18n future mezzanine_tags accounts_tags %}
+{% load i18n mezzanine_tags accounts_tags %}
 
 {% if request.user.is_authenticated %}
     <li>

--- a/flat/templates/accounts/includes/user_panel_nav.html
+++ b/flat/templates/accounts/includes/user_panel_nav.html
@@ -1,4 +1,4 @@
-{% load i18n future mezzanine_tags accounts_tags %}
+{% load i18n mezzanine_tags accounts_tags %}
 
 <div class="navbar-right navbar-account-controls">
     {% if request.user.is_authenticated %}

--- a/flat/templates/base.html
+++ b/flat/templates/base.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="{{ LANGUAGE_CODE }}"{% if LANGUAGE_BIDI %} dir="rtl"{% endif %}>
-{% load pages_tags mezzanine_tags i18n future staticfiles %}
+{% load pages_tags mezzanine_tags i18n staticfiles %}
 
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8">

--- a/flat/templates/blog/blog_post_detail.html
+++ b/flat/templates/blog/blog_post_detail.html
@@ -1,5 +1,5 @@
 {% extends "blog/blog_post_list.html" %}
-{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n future disqus_tags %}
+{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n disqus_tags %}
 
 {% block meta_title %}{{ blog_post.meta_title }}{% endblock %}
 

--- a/flat/templates/blog/blog_post_list.html
+++ b/flat/templates/blog/blog_post_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n future mezzanine_tags blog_tags keyword_tags disqus_tags %}
+{% load i18n mezzanine_tags blog_tags keyword_tags disqus_tags %}
 
 {% block meta_title %}{% if page %}{{ page.meta_title }}{% else %}{% trans "Blog" %}{% endif %}{% endblock %}
 

--- a/flat/templates/blog/includes/filter_panel.html
+++ b/flat/templates/blog/includes/filter_panel.html
@@ -1,4 +1,4 @@
-{% load blog_tags keyword_tags i18n future %}
+{% load blog_tags keyword_tags i18n %}
 
 {% block blog_recent_posts %}
 {% blog_recent_posts 5 as recent_posts %}

--- a/flat/templates/generic/includes/rating.html
+++ b/flat/templates/generic/includes/rating.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags rating_tags i18n future %}
+{% load mezzanine_tags rating_tags i18n %}
 
 <span id="rating-{{ rating_object.id }}">
     {% if rating_average %}

--- a/flat/templates/includes/editable_form.html
+++ b/flat/templates/includes/editable_form.html
@@ -1,4 +1,4 @@
-{% load i18n future %}
+{% load i18n %}
 
 {# Edit form #}
 <form style="display:none;" class="editable-form" method="post"

--- a/flat/templates/includes/editable_loader.html
+++ b/flat/templates/includes/editable_loader.html
@@ -1,4 +1,4 @@
-{% load i18n future staticfiles %}
+{% load i18n staticfiles %}
 
 {% if has_site_permission %}
 <link rel="stylesheet" href="{% static "mezzanine/css/editable.css" %}">

--- a/flat/templates/includes/editable_toolbar.html
+++ b/flat/templates/includes/editable_toolbar.html
@@ -1,4 +1,4 @@
-{% load i18n future staticfiles %}
+{% load i18n staticfiles %}
 
 <div id="editable-toolbar" method="POST" action="{% url "admin:logout" %}">
     {% url "admin:index" as admin_index_url %}

--- a/flat/templates/includes/search_form.html
+++ b/flat/templates/includes/search_form.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags i18n future %}
+{% load mezzanine_tags i18n %}
 <form action="{% url "search" %}" class="navbar-form navbar-right" role="search">
 
 <div class="form-group">

--- a/flat/templates/pages/index.html
+++ b/flat/templates/pages/index.html
@@ -1,5 +1,5 @@
 {% extends "pages/page.html" %}
-{% load pages_tags mezzanine_tags i18n future staticfiles blog_tags keyword_tags %}
+{% load pages_tags mezzanine_tags i18n staticfiles blog_tags keyword_tags %}
 
 {% block top %}{% endblock %}
 {% block main %}

--- a/flat/templates/pages/menus/admin.html
+++ b/flat/templates/pages/menus/admin.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future staticfiles %}
+{% load pages_tags i18n staticfiles %}
 
 <ol>
     {% for page in page_branch %}

--- a/flat/templates/pages/menus/breadcrumb.html
+++ b/flat/templates/pages/menus/breadcrumb.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% if on_home %}
 <li>{% trans "Home" %}</li>

--- a/flat/templates/pages/menus/dropdown.html
+++ b/flat/templates/pages/menus/dropdown.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags mezzanine_tags%}
+{% load i18n pages_tags mezzanine_tags%}
 {% spaceless %}
 {% if page_branch_in_menu %}
 

--- a/flat/templates/pages/menus/footer.html
+++ b/flat/templates/pages/menus/footer.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags blog_tags keyword_tags mezzanine_tags %}
+{% load i18n pages_tags blog_tags keyword_tags mezzanine_tags %}
 
 
                 <div class="col-md-3 col-sm-6">

--- a/flat/templates/pages/menus/footer_tree.html
+++ b/flat/templates/pages/menus/footer_tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/flat/templates/pages/menus/mobile.html
+++ b/flat/templates/pages/menus/mobile.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch %}

--- a/flat/templates/pages/menus/primary.html
+++ b/flat/templates/pages/menus/primary.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future %}
+{% load pages_tags i18n %}
 
 {% spaceless %}
 <ul id="primary-menu" class="nav pull-right">

--- a/flat/templates/pages/menus/tree.html
+++ b/flat/templates/pages/menus/tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/flat/templates/search_results.html
+++ b/flat/templates/search_results.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n future mezzanine_tags %}
+{% load i18n mezzanine_tags %}
 
 {% block meta_title %}{% trans "Search Results" %}{% endblock %}
 {% block title %}{% trans "Search Results" %}{% endblock %}

--- a/moderna/templates/base.html
+++ b/moderna/templates/base.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="{{ LANGUAGE_CODE }}"{% if LANGUAGE_BIDI %} dir="rtl"{% endif %}>
-{% load pages_tags mezzanine_tags i18n future staticfiles %}
+{% load pages_tags mezzanine_tags i18n staticfiles %}
 
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8">

--- a/moderna/templates/blog/blog_post_detail.html
+++ b/moderna/templates/blog/blog_post_detail.html
@@ -1,5 +1,5 @@
 {% extends "blog/blog_post_list.html" %}
-{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n future disqus_tags %}
+{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n disqus_tags %}
 
 {% block meta_title %}{{ blog_post.meta_title }}{% endblock %}
 

--- a/moderna/templates/blog/blog_post_list.html
+++ b/moderna/templates/blog/blog_post_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n future mezzanine_tags blog_tags keyword_tags disqus_tags %}
+{% load i18n mezzanine_tags blog_tags keyword_tags disqus_tags %}
 
 {% block meta_title %}{% if page %}{{ page.meta_title }}{% else %}{% trans "Blog" %}{% endif %}{% endblock %}
 

--- a/moderna/templates/blog/includes/filter_panel.html
+++ b/moderna/templates/blog/includes/filter_panel.html
@@ -1,4 +1,4 @@
-{% load blog_tags keyword_tags i18n future mezzanine_tags %}
+{% load blog_tags keyword_tags i18n mezzanine_tags %}
 {% block blog_recent_posts %}
 {% blog_recent_posts 5 as recent_posts %}
 {% if recent_posts %}

--- a/moderna/templates/generic/includes/rating.html
+++ b/moderna/templates/generic/includes/rating.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags rating_tags i18n future %}
+{% load mezzanine_tags rating_tags i18n %}
 
 <span id="rating-{{ rating_object.id }}">
     {% if rating_average %}

--- a/moderna/templates/pages/menus/admin.html
+++ b/moderna/templates/pages/menus/admin.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future staticfiles %}
+{% load pages_tags i18n staticfiles %}
 
 <ol>
     {% for page in page_branch %}

--- a/moderna/templates/pages/menus/breadcrumb.html
+++ b/moderna/templates/pages/menus/breadcrumb.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% if on_home %}
 <li>{% trans "Home" %}</li>

--- a/moderna/templates/pages/menus/dropdown.html
+++ b/moderna/templates/pages/menus/dropdown.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 {% spaceless %}
 {% if page_branch_in_menu %}
 

--- a/moderna/templates/pages/menus/footer.html
+++ b/moderna/templates/pages/menus/footer.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/moderna/templates/pages/menus/footer_tree.html
+++ b/moderna/templates/pages/menus/footer_tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/moderna/templates/pages/menus/mobile.html
+++ b/moderna/templates/pages/menus/mobile.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch %}

--- a/moderna/templates/pages/menus/primary.html
+++ b/moderna/templates/pages/menus/primary.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future %}
+{% load pages_tags i18n %}
 
 {% spaceless %}
 <ul id="primary-menu" class="nav pull-right">

--- a/moderna/templates/pages/menus/tree.html
+++ b/moderna/templates/pages/menus/tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/moderna/templates/search_results.html
+++ b/moderna/templates/search_results.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n future mezzanine_tags %}
+{% load i18n mezzanine_tags %}
 
 {% block meta_title %}{% trans "Search Results" %}{% endblock %}
 {% block title %}{% trans "Search Results" %}{% endblock %}

--- a/nova/templates/base.html
+++ b/nova/templates/base.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="{{ LANGUAGE_CODE }}"{% if LANGUAGE_BIDI %} dir="rtl"{% endif %}>
-{% load pages_tags mezzanine_tags i18n future staticfiles %}
+{% load pages_tags mezzanine_tags i18n staticfiles %}
 
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8">

--- a/nova/templates/blog/blog_post_detail.html
+++ b/nova/templates/blog/blog_post_detail.html
@@ -1,5 +1,5 @@
 {% extends "blog/blog_post_list.html" %}
-{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n future disqus_tags %}
+{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n disqus_tags %}
 
 {% block meta_title %}{{ blog_post.meta_title }}{% endblock %}
 

--- a/nova/templates/blog/blog_post_list.html
+++ b/nova/templates/blog/blog_post_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n future mezzanine_tags blog_tags keyword_tags disqus_tags %}
+{% load i18n mezzanine_tags blog_tags keyword_tags disqus_tags %}
 
 {% block meta_title %}{% if page %}{{ page.meta_title }}{% else %}{% trans "Blog" %}{% endif %}{% endblock %}
 

--- a/nova/templates/blog/includes/filter_panel.html
+++ b/nova/templates/blog/includes/filter_panel.html
@@ -1,4 +1,4 @@
-{% load blog_tags keyword_tags i18n future mezzanine_tags %}
+{% load blog_tags keyword_tags i18n mezzanine_tags %}
 
 {% block blog_categories %}
 {% blog_categories as categories %}

--- a/nova/templates/generic/includes/rating.html
+++ b/nova/templates/generic/includes/rating.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags rating_tags i18n future %}
+{% load mezzanine_tags rating_tags i18n %}
 
 <span id="rating-{{ rating_object.id }}">
     {% if rating_average %}

--- a/nova/templates/pages/menus/admin.html
+++ b/nova/templates/pages/menus/admin.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future staticfiles %}
+{% load pages_tags i18n staticfiles %}
 
 <ol>
     {% for page in page_branch %}

--- a/nova/templates/pages/menus/breadcrumb.html
+++ b/nova/templates/pages/menus/breadcrumb.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% if on_home %}
 <li>{% trans "Home" %}</li>

--- a/nova/templates/pages/menus/dropdown.html
+++ b/nova/templates/pages/menus/dropdown.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 {% spaceless %}
 {% if page_branch_in_menu %}
 

--- a/nova/templates/pages/menus/footer.html
+++ b/nova/templates/pages/menus/footer.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/nova/templates/pages/menus/footer_tree.html
+++ b/nova/templates/pages/menus/footer_tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/nova/templates/pages/menus/mobile.html
+++ b/nova/templates/pages/menus/mobile.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch %}

--- a/nova/templates/pages/menus/primary.html
+++ b/nova/templates/pages/menus/primary.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future %}
+{% load pages_tags i18n %}
 
 {% spaceless %}
 <ul id="primary-menu" class="nav pull-right">

--- a/nova/templates/pages/menus/tree.html
+++ b/nova/templates/pages/menus/tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/nova/templates/search_results.html
+++ b/nova/templates/search_results.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n future mezzanine_tags %}
+{% load i18n mezzanine_tags %}
 
 {% block meta_title %}{% trans "Search Results" %}{% endblock %}
 {% block title %}{% trans "Search Results" %}{% endblock %}

--- a/solid/templates/base.html
+++ b/solid/templates/base.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html lang="{{ LANGUAGE_CODE }}"{% if LANGUAGE_BIDI %} dir="rtl"{% endif %}>
-{% load pages_tags mezzanine_tags i18n future staticfiles %}
+{% load pages_tags mezzanine_tags i18n staticfiles %}
 
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8">

--- a/solid/templates/blog/blog_post_detail.html
+++ b/solid/templates/blog/blog_post_detail.html
@@ -1,5 +1,5 @@
 {% extends "blog/blog_post_list.html" %}
-{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n future disqus_tags %}
+{% load mezzanine_tags comment_tags keyword_tags rating_tags i18n disqus_tags %}
 
 {% block meta_title %}{{ blog_post.meta_title }}{% endblock %}
 

--- a/solid/templates/blog/blog_post_list.html
+++ b/solid/templates/blog/blog_post_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n future mezzanine_tags blog_tags keyword_tags disqus_tags %}
+{% load i18n mezzanine_tags blog_tags keyword_tags disqus_tags %}
 
 {% block meta_title %}{% if page %}{{ page.meta_title }}{% else %}{% trans "Blog" %}{% endif %}{% endblock %}
 

--- a/solid/templates/blog/includes/filter_panel.html
+++ b/solid/templates/blog/includes/filter_panel.html
@@ -1,4 +1,4 @@
-{% load blog_tags keyword_tags i18n future mezzanine_tags%}
+{% load blog_tags keyword_tags i18n mezzanine_tags%}
 
 {% block blog_recent_posts %}
 {% blog_recent_posts 5 as recent_posts %}

--- a/solid/templates/generic/includes/rating.html
+++ b/solid/templates/generic/includes/rating.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags rating_tags i18n future %}
+{% load mezzanine_tags rating_tags i18n %}
 
 <span id="rating-{{ rating_object.id }}">
     {% if rating_average %}

--- a/solid/templates/includes/editable_form.html
+++ b/solid/templates/includes/editable_form.html
@@ -1,4 +1,4 @@
-{% load i18n future %}
+{% load i18n %}
 
 {# Edit form #}
 <form style="display:none;" class="editable-form" method="post"

--- a/solid/templates/includes/editable_loader.html
+++ b/solid/templates/includes/editable_loader.html
@@ -1,4 +1,4 @@
-{% load i18n future staticfiles %}
+{% load i18n staticfiles %}
 
 {% if has_site_permission %}
 <link rel="stylesheet" href="{% static "mezzanine/css/editable.css" %}">

--- a/solid/templates/includes/editable_toolbar.html
+++ b/solid/templates/includes/editable_toolbar.html
@@ -1,4 +1,4 @@
-{% load i18n future staticfiles %}
+{% load i18n staticfiles %}
 
 <div id="editable-toolbar" method="POST" action="{% url "admin:logout" %}">
     {% url "admin:index" as admin_index_url %}

--- a/solid/templates/includes/search_form.html
+++ b/solid/templates/includes/search_form.html
@@ -1,4 +1,4 @@
-{% load mezzanine_tags i18n future %}
+{% load mezzanine_tags i18n %}
 <form action="{% url "search" %}" class="navbar-form navbar-right" role="search">
 
 <div class="form-group">

--- a/solid/templates/pages/menus/admin.html
+++ b/solid/templates/pages/menus/admin.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future staticfiles %}
+{% load pages_tags i18n staticfiles %}
 
 <ol>
     {% for page in page_branch %}

--- a/solid/templates/pages/menus/breadcrumb.html
+++ b/solid/templates/pages/menus/breadcrumb.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% if on_home %}
 <li>{% trans "Home" %}</li>

--- a/solid/templates/pages/menus/dropdown1.html
+++ b/solid/templates/pages/menus/dropdown1.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 {% spaceless %}
 {% if page_branch_in_menu %}
 

--- a/solid/templates/pages/menus/footer.html
+++ b/solid/templates/pages/menus/footer.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/solid/templates/pages/menus/footer_tree.html
+++ b/solid/templates/pages/menus/footer_tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/solid/templates/pages/menus/mobile.html
+++ b/solid/templates/pages/menus/mobile.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch %}

--- a/solid/templates/pages/menus/primary.html
+++ b/solid/templates/pages/menus/primary.html
@@ -1,4 +1,4 @@
-{% load pages_tags i18n future %}
+{% load pages_tags i18n %}
 
 {% spaceless %}
 <ul id="primary-menu" class="nav pull-right">

--- a/solid/templates/pages/menus/tree.html
+++ b/solid/templates/pages/menus/tree.html
@@ -1,4 +1,4 @@
-{% load i18n future pages_tags %}
+{% load i18n pages_tags %}
 
 {% spaceless %}
 {% if page_branch_in_menu %}

--- a/solid/templates/search_results.html
+++ b/solid/templates/search_results.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n future mezzanine_tags %}
+{% load i18n mezzanine_tags %}
 
 {% block meta_title %}{% trans "Search Results" %}{% endblock %}
 {% block title %}{% trans "Search Results" %}{% endblock %}


### PR DESCRIPTION
From [Django docs](https://docs.djangoproject.com/en/1.8/releases/1.7/#loading-ssi-and-url-template-tags-from-future-library):

>Loading ssi and url template tags from future library¶
>Django 1.3 introduced {% load ssi from future %} and {% load url from future %} syntax for forward >compatibility of the ssi and url template tags. This syntax is now deprecated and will be removed in >**Django 1.9.** You can simply remove the {% load ... from future %} tags.
